### PR TITLE
CTDC-1892: Add comma to CMB participant count 

### DIFF
--- a/banners/banner_content.yaml
+++ b/banners/banner_content.yaml
@@ -9,7 +9,7 @@
 # Example usage for GenericBanner component.
 
 banner_show: true  # (true/false) Show or hide this banner
-banner_text: "The Cancer Moonshot Biobank (CMB) data currently at CTDC is preliminary. As additional data is prepared and validated, it will be released to CTDC in stages until complete. CMB data will ultimately cover over 1000 participants."
+banner_text: "The Cancer Moonshot Biobank (CMB) data currently at CTDC is preliminary. As additional data is prepared and validated, it will be released to CTDC in stages until complete. CMB data will ultimately cover over 1,000 participants."
 banner_style:
   background: "#E8F1F7"    # Light blue background
   color: "#1F3A4D"         # Dark blue text


### PR DESCRIPTION
Changed the banner text to display 'over 1,000 participants' instead of 'over 1000 participants' for improved readability.