### PR TITLE
CTDC-2168: Sync the changes from develop to qa branch

### DIFF
--- a/aboutPagesContent.yaml
+++ b/aboutPagesContent.yaml
@@ -3,7 +3,7 @@
   primaryContentImage: https://raw.githubusercontent.com/CBIIT/datacommons-assets/ctdc_Assets/ctdc/images/aboutPages/About_CRDC.png
   content:
     - paragraph: "The Clinical and Translational Data Commons (CTDC) is designed to facilitate the integration and analysis of a wide array of clinical and translational research data. To support this initiative, the CTDC will accept a variety of data types, each crucial for the comprehensive understanding of clinical outcomes and the translational pathway from laboratory and clinical research to clinical applications."
-    - paragraph: "Those interested in submitting data to the CTDC must first fill out a data submission request through $$[the CRDC Submission Portal](https://hub.datacommons.cancer.gov/)$$. Requests will be reviewed to assess alignment with CTDC and CRDC's mission and overall data requirements. Review times can be expected to be four to six weeks. For more information regarding submission requests and data submission, see $$[CRDC's Submit Data page](https://datacommons.cancer.gov/submit)$$ or contact $$[NCICRDC@mail.nih.gov✉️](mailto:NCICRDC@mail.nih.gov)$$."
+    - paragraph: "Those interested in submitting data to the CTDC must first fill out a data submission request through $$[the CRDC Submission Portal](https://hub.datacommons.cancer.gov/)$$. Requests will be reviewed to assess alignment with CTDC and CRDC's mission and overall data requirements. Review times can be expected to be four to six weeks. For more information regarding submission requests and data submission, see $$[CRDC's Submit Data page](https://datacommons.cancer.gov/submit)$$ or contact $$[NCICRDC@mail.nih.gov](NCICRDC@mail.nih.gov)$$."
     - paragraph: "Below are the primary categories of data the CTDC currently accepts:"
     - paragraph: "$$*De-identified Clinical Data:*$$"
     - listWithDots:
@@ -95,7 +95,7 @@
   title: "Support"
   primaryContentImage: https://raw.githubusercontent.com/CBIIT/datacommons-assets/ctdc_Assets/ctdc/images/aboutPages/About_Support.png
   content:
-    - paragraph: "If you have any questions, please contact us at $$[NCICRDC@mail.nih.gov✉️](mailto:NCICRDC@mail.nih.gov)$$."
+    - paragraph: "If you have any questions, please contact us at $$[NCICRDC@mail.nih.gov](NCICRDC@mail.nih.gov)$$."
 - page: '/cloud-computing'
   title: "Cloud computing"
   primaryContentImage: https://raw.githubusercontent.com/CBIIT/datacommons-assets/ctdc_Assets/ctdc/images/aboutPages/About_CRDC.png
@@ -135,14 +135,14 @@
     - paragraph: "     "
     - paragraph: "$$!\"The results published here are, in whole or in part, derived from the analysis of data found within the Clinical and Translational Data Commons (CTDC), part of the National Cancer Institute's Cancer Research Data Commons (CRDC). This includes data generated as part of the [Study Name] NCT XXXXXX study, https://doi.org/xxx. This data can be found within NCI’s Clinical and Translational Data Commons, found at clinical.datacommons.cancer.gov.\"!$$"
     - paragraph: "     "
-    - paragraph: "If you have utilized data within the CTDC in your research, please contact $$[NCICRDC@mail.nih.gov](mailto:NCICRDC@mail.nih.gov)$$ so we can include your work on our website."
+    - paragraph: "If you have utilized data within the CTDC in your research, please contact $$[NCICRDC@mail.nih.gov](NCICRDC@mail.nih.gov)$$ so we can include your work on our website."
     - paragraph: "     "
     - paragraph: "$$#Intellectual Property#$$"
     - paragraph: "     "
     - paragraph: "CTDC discourages users from making intellectual property (IP) claims derived directly from the available dataset(s). CTDC-provided data, and conclusions derived thereof, shall remain freely available, without license requirements. However, the CTDC also recognizes the importance of the subsequent development of IP on downstream discoveries, especially in therapeutics, which will be necessary to support full investment in products that the public needs. "
     - paragraph: "     "
     - paragraph: "$$#Questions#$$"
-    - paragraph: "Please contact $$[NCICRDC@mail.nih.gov](mailto:NCICRDC@mail.nih.gov)$$ with any questions or concerns related to data."
+    - paragraph: "Please contact $$[NCICRDC@mail.nih.gov](NCICRDC@mail.nih.gov)$$ with any questions or concerns related to data."
 - page: '/data-harmonization'
   title: "Data Harmonization"
   primaryContentImage: https://raw.githubusercontent.com/CBIIT/datacommons-assets/ctdc_Assets/ctdc/images/aboutPages/About_CRDC.png

--- a/aboutPagesContent.yaml
+++ b/aboutPagesContent.yaml
@@ -3,7 +3,7 @@
   primaryContentImage: https://raw.githubusercontent.com/CBIIT/datacommons-assets/ctdc_Assets/ctdc/images/aboutPages/About_CRDC.png
   content:
     - paragraph: "The Clinical and Translational Data Commons (CTDC) is designed to facilitate the integration and analysis of a wide array of clinical and translational research data. To support this initiative, the CTDC will accept a variety of data types, each crucial for the comprehensive understanding of clinical outcomes and the translational pathway from laboratory and clinical research to clinical applications."
-    - paragraph: "Those interested in submitting data to the CTDC must first fill out a data submission request through $$[the CRDC Submission Portal](https://hub.datacommons.cancer.gov/)$$. Requests will be reviewed to assess alignment with CTDC and CRDC’s mission and overall data requirements. Review times can be expected to be four to six weeks. For more information regarding submission requests and data submission, see $$[CRDC’s Submit Data page](https://datacommons.cancer.gov/submit)$$ or contact $$[NCICRDC@mail.nih.gov✉️](type: email NCICRDC@mail.nih.gov)$$."
+    - paragraph: "Those interested in submitting data to the CTDC must first fill out a data submission request through $$[the CRDC Submission Portal](https://hub.datacommons.cancer.gov/)$$. Requests will be reviewed to assess alignment with CTDC and CRDC's mission and overall data requirements. Review times can be expected to be four to six weeks. For more information regarding submission requests and data submission, see $$[CRDC's Submit Data page](https://datacommons.cancer.gov/submit)$$ or contact $$[NCICRDC@mail.nih.gov✉️](mailto:NCICRDC@mail.nih.gov)$$."
     - paragraph: "Below are the primary categories of data the CTDC currently accepts:"
     - paragraph: "$$*De-identified Clinical Data:*$$"
     - listWithDots:
@@ -95,7 +95,7 @@
   title: "Support"
   primaryContentImage: https://raw.githubusercontent.com/CBIIT/datacommons-assets/ctdc_Assets/ctdc/images/aboutPages/About_Support.png
   content:
-    - paragraph: "If you have any questions, please contact us at $$[NCICRDC@mail.nih.gov✉️](type: email NCICRDC@mail.nih.gov)$$."
+    - paragraph: "If you have any questions, please contact us at $$[NCICRDC@mail.nih.gov✉️](mailto:NCICRDC@mail.nih.gov)$$."
 - page: '/cloud-computing'
   title: "Cloud computing"
   primaryContentImage: https://raw.githubusercontent.com/CBIIT/datacommons-assets/ctdc_Assets/ctdc/images/aboutPages/About_CRDC.png
@@ -135,14 +135,14 @@
     - paragraph: "     "
     - paragraph: "$$!\"The results published here are, in whole or in part, derived from the analysis of data found within the Clinical and Translational Data Commons (CTDC), part of the National Cancer Institute's Cancer Research Data Commons (CRDC). This includes data generated as part of the [Study Name] NCT XXXXXX study, https://doi.org/xxx. This data can be found within NCI’s Clinical and Translational Data Commons, found at clinical.datacommons.cancer.gov.\"!$$"
     - paragraph: "     "
-    - paragraph: "If you have utilized data within the CTDC in your research, please contact $$[NCICRDC@mail.nih.gov](NCICRDC@mail.nih.gov)$$ so we can include your work on our website."
+    - paragraph: "If you have utilized data within the CTDC in your research, please contact $$[NCICRDC@mail.nih.gov](mailto:NCICRDC@mail.nih.gov)$$ so we can include your work on our website."
     - paragraph: "     "
     - paragraph: "$$#Intellectual Property#$$"
     - paragraph: "     "
     - paragraph: "CTDC discourages users from making intellectual property (IP) claims derived directly from the available dataset(s). CTDC-provided data, and conclusions derived thereof, shall remain freely available, without license requirements. However, the CTDC also recognizes the importance of the subsequent development of IP on downstream discoveries, especially in therapeutics, which will be necessary to support full investment in products that the public needs. "
     - paragraph: "     "
     - paragraph: "$$#Questions#$$"
-    - paragraph: "Please contact $$[NCICRDC@mail.nih.gov](NCICRDC@mail.nih.gov)$$ with any questions or concerns related to data."
+    - paragraph: "Please contact $$[NCICRDC@mail.nih.gov](mailto:NCICRDC@mail.nih.gov)$$ with any questions or concerns related to data."
 - page: '/data-harmonization'
   title: "Data Harmonization"
   primaryContentImage: https://raw.githubusercontent.com/CBIIT/datacommons-assets/ctdc_Assets/ctdc/images/aboutPages/About_CRDC.png


### PR DESCRIPTION
This pull request updates the `aboutPagesContent.yaml` file to improve the formatting and consistency of email links and apostrophe usage in the About and Support sections.

Content and formatting improvements:

* Standardized the email link formatting by removing the "✉️" emoji and using a consistent link format for `NCICRDC@mail.nih.gov` in both the data submission and support sections. [[1]](diffhunk://#diff-e26e38b4403d0642d05121695d7dfd440e69666429742c97e8f5dab8076c4968L6-R6) [[2]](diffhunk://#diff-e26e38b4403d0642d05121695d7dfd440e69666429742c97e8f5dab8076c4968L98-R98)
* Corrected apostrophe usage in "CRDC's mission" and "CRDC's Submit Data page" for grammatical consistency.